### PR TITLE
Disable annobin, which validates fortification

### DIFF
--- a/rpm/template.spec.em
+++ b/rpm/template.spec.em
@@ -35,6 +35,7 @@ Source0:        %{name}-%{version}.tar.gz
 
 %build
 # Suppress fortification, which conflicts with Mimick's -O0 requirement
+%undefine _annotated_build
 export CFLAGS="${CFLAGS:-%{optflags}} -Wp,-U_FORTIFY_SOURCE"
 
 # In case we're installing to a non-standard location, look for a setup.sh


### PR DESCRIPTION
This is a follow-up to the existing patch (#2) which is necessary to handle additional checks in RPM builds for RHEL 9.